### PR TITLE
tree: fix bugs when using a list of tables as keys 

### DIFF
--- a/src/tree.lua
+++ b/src/tree.lua
@@ -19,7 +19,9 @@ end
 -- @return <code>tr[i]...[i<sub>n</sub>]</code> if i is a table, or
 -- <code>tr[i]</code> otherwise
 function metatable.__index (tr, i)
-  if type (i) == "table" then
+  -- FIXME: the following doesn't treat list keys correctly
+  --        e.g. tr[{{1, 2}, {3, 4}}], maybe flatten first?
+  if type (i) == "table" and #i > 0 then
     return list.foldl (op["[]"], tr, i)
   else
     return rawget (tr, i)
@@ -36,8 +38,8 @@ end
 function metatable.__newindex (tr, i, v)
   if type (i) == "table" then
     for n = 1, #i - 1 do
-      if type (tr[i[n]]) ~= "table" then
-        tr[i[n]] = tree.new ()
+      if getmetatable (tr[i[n]]) ~= metatable then
+        rawset (tr, i[n], tree.new ())
       end
       tr = tr[i[n]]
     end


### PR DESCRIPTION
To be fully general, tree should allow table keys so that it's
possible to write:
  $ lua -lstd

> t, k1, k2 = tree.new(), {key='a'}, {key='b'}
> t[{"k1", "k2"}] = "string keys"; t[{k1, k2}] = "table keys"
> = t[{"k1", "k2"}], t[{k1, k2}]
>   string keys    table keys
> This patch fixes 3 bugs that prevent that from working.
> - src/tree.lua (metatable.__newindex): Detect subtrees correctly
>   by comparing against the tree metatable, rather than assuming any
>   "table" type is a correct match.
>   Use rawset to insert a new node without triggering the __index
>   metamethod.
>   (metatable.__index): Don't recurse into table key members, only
>   the list entries to be folded, by checking whether the table has
>   a length first - for t[{k1, k2}], {k1, k2} is a list (with length)
>   and should be folded, but k1 (k1 = {key='a'}) is not a list and
>   should not.
