### PR TITLE
base.lua: fix tree folding lookup on missing keys.

### DIFF
--- a/src/base.lua
+++ b/src/base.lua
@@ -466,7 +466,11 @@ end
 -- FIXME: Make these visible in LuaDoc (also list.concat in list)
 _G.op["[]"] =
   function (t, s)
-    return t[s]
+    if type(t) == "table" then
+      return t[s]
+    else
+      return t
+    end
   end
 
 _G.op["+"] =


### PR DESCRIPTION
Since _G.fold is generic, it can't tell whether the function it
calls will try to do something illegal with the values it is
passed. So, it's possible to get a stack dump with:
  $ lua -lstd

> x = tree.new ()
> return x[{1,2}]
> because the second fold iteration calls `_G.op["[]"] (nil, 2)'
> when there is no match from the earlier`_G.op["[]"]({}, 1)'.
> The easiest way to prevent that is in the operator function
> itself.
> - src/base.lua (op["[]"]): Don't try to take the index of a
>   non-table.
