### PR TITLE
* configury: load  local std modules as expected by mkrockspecs.lua.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,9 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
+LUA_PATH ?= ;
+LUA_ENV = LUA_PATH="$(abs_srcdir)/src/?.lua;$(LUA_PATH)"
+
 SOURCES = $(wildcard $(srcdir)/src/*.lua)
 dist_data_DATA = $(SOURCES)
 
@@ -31,8 +34,8 @@ $(dist_doc_DATA): $(SOURCES)
 
 rockspecs:
 	rm -f *.rockspec
-	$(LUA) mkrockspecs.lua $(PACKAGE) $(VERSION)
-	$(LUA) mkrockspecs.lua $(PACKAGE) git
+	$(LUA_ENV) $(LUA) mkrockspecs.lua $(PACKAGE) $(VERSION)
+	$(LUA_ENV) $(LUA) mkrockspecs.lua $(PACKAGE) git
 
 bootstrap:
 	autoreconf -i && \


### PR DESCRIPTION
Rather than having to manually update the installed lua-stdlib
behind luarocks' back, let the mkrockspecs.lua script find the
modules it was written for in the source tree.
- Makefile.am (LUA_PATH): Default to compiled-in search path.
  (LUA_ENV): Load modules from the source tree instead of potentially
  outdated versions from the lua installation.
  (rockspecs): Run lua with LUA_ENV set.
