### PR TITLE
configury: make sure we build std.lua when necessary.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SOURCES = $(wildcard $(srcdir)/src/*.lua)
+SOURCES = $(wildcard $(srcdir)/src/*.lua) $(srcdir)/src/std.lua
 dist_data_DATA = $(SOURCES)
 
 dist_doc_DATA =				\


### PR DESCRIPTION
Using wildcard for SOURCES before std.lua has been built now that
configure no longer makes it for us, means standard make or
luarocks install after building from a fresh checkout results in
std.lua not being built or installed.
- Makefile.am (SOURCES): Add src/std.lua.

NOTE: Be careful of the merge conflict when accepting the pull request.
(See my next branch for the correct resolution if in doubt!)
