### PR TITLE
package_ext: don't perturb the global environment by default.

### DIFF
--- a/specs/package_ext_spec.yaml
+++ b/specs/package_ext_spec.yaml
@@ -1,25 +1,61 @@
 specify package_ext:
-- before:
-    unextended = require "package_ext"
-- context when requiring the module:
-  - before: |
-      -- do not try to check all the entries in unextended package,
-      -- because they naturally change as modules are loaded.
-      apis = { "config", "cpath", "loaders", "loadlib", "preload",
-               "searchers", "searchpath", "seeall" }
+- before: |
+    -- Do not try to check all the entries in unextended package,
+    -- because they naturally change as modules are loaded.
+    coreapis = { "config", "cpath", "loaders", "loadlib", "preload",
+                 "searchers", "searchpath", "seeall" }
+    newapis  = { "dirsep", "pathsep", "path_mark",  "execdir", "igmark" }
 
-  - it returns the unextended package table:
-      expect (unextended.config).should_be (package.config)
-      expect (unextended.dirsep).should_be (nil)
-      expect (unextended.pathsep).should_be (nil)
-      expect (unextended.path_mark).should_be (nil)
-      expect (unextended.execdir).should_be (nil)
-      expect (unextended.igmark).should_be (nil)
+    -- `require "std"` side-effects all kinds of global state, clean up
+    -- at least the parts we care about in case another test already
+    -- did a `require "std"` -- which would otherwise leak out here!
+    saved_global_state = {}
+    for _, api in ipairs (newapis) do
+      saved_global_state[api] = package[api]
+      package[api] = nil
+    end
+
+    -- Store addresses of core functions in pristine (as far as possible)
+    -- state.
+    unextended = {}
+    for _, api in ipairs (coreapis) do
+      unextended[api] = package[api]
+    end
+
+    pkgx = require "package_ext"
+
+- after: |
+    -- Undo side-effects of before block above.
+    for k, v in pairs (saved_global_state) do
+      package[k] = v
+    end
+
+- context when loaded directly:
+  - "it splits package.config up":
+      expect (string.format ("%s\n%s\n%s\n%s\n%s\n",
+              pkgx.dirsep, pkgx.pathsep, pkgx.path_mark, pkgx.execdir, pkgx.igmark)
+      ).should_contain (package.config)
+  - it does not perturb the system package module:
+      for _, api in ipairs (newapis) do
+        expect (package[api]).should_be (nil)
+  - it does not contain any other access points:
+      for _, api in ipairs (coreapis) do
+        expect (pkgx[api]).should_be (nil)
+      end
+
+- context when loaded via the std module:
+  - before:
+      require "std"
+
   - "it splits package.config up":
       expect (string.format ("%s\n%s\n%s\n%s\n%s\n",
               package.dirsep, package.pathsep, package.path_mark, package.execdir, package.igmark)
       ).should_contain (package.config)
+  - it injects the exteded package table:
+      for _, api in ipairs (newapis) do
+        expect (package[api]).should_be (pkgx[api])
+      end
   - it does not override any other module access points:
-      for _, api in ipairs (apis) do
+      for _, api in ipairs (coreapis) do
         expect (package[api]).should_be (unextended[api])
       end

--- a/src/package_ext.lua
+++ b/src/package_ext.lua
@@ -1,9 +1,6 @@
 -- Additions to the package module.
 
-local table_unext = require "table_ext"
-
--- Save original unextended table.
-local unextended = table.clone (package)
+local M = {}
 
 --- Make named constants for <code>package.config</code> (undocumented
 -- in 5.1; see luaconf.h for C equivalents).
@@ -14,7 +11,7 @@ local unextended = table.clone (package)
 -- @field path_mark string that marks substitution points in a path template
 -- @field execdir (Windows only) replaced by the executable's directory in a path
 -- @field igmark Mark to ignore all before it when building <code>luaopen_</code> function name.
-package.dirsep, package.pathsep, package.path_mark, package.execdir, package.igmark =
+M.dirsep, M.pathsep, M.path_mark, M.execdir, M.igmark =
   string.match (package.config, "^([^\n]+)\n([^\n]+)\n([^\n]+)\n([^\n]+)\n([^\n]+)")
 
-return unextended
+return M

--- a/src/std.lua.in
+++ b/src/std.lua.in
@@ -13,6 +13,8 @@ for _, m in ipairs (require "modules") do
   _G[m] = require (m)
 end
 
+_G.package = table.merge (_G.package, _G.package_ext)
+
 local M = {
   version = version,
 }


### PR DESCRIPTION
For backwards compatibility, `require "std"` will still write
symbols into the global namespace, but when loaded directly be
much more hygienic and return everything in a table, like most
other modules:
- src/package_ext.lua (M): Define module symbols in this table
  and return it.
- src/std.lua.in: Inject package_ext module symbols into global
  namespace.
- specs/package_ext_spec.yaml: Specify new behaviour, being
  careful about `require "std"` side-effects.
