### PR TITLE
base: require does not work with non-string module version fields

### DIFF
--- a/lib/std/base.lua
+++ b/lib/std/base.lua
@@ -373,7 +373,7 @@ local _require = require
 
 local function require (module, min, too_big, pattern)
   local m = _require (module)
-  local v = (m.version or m._VERSION or ""):match (pattern or "([%.%d]+)%D*$")
+  local v = tostring (m.version or m._VERSION or ""):match (pattern or "([%.%d]+)%D*$")
   if min then
     assert (vcompare (v, min) >= 0, "require '" .. module ..
             "' with at least version " .. min .. ", but found version " .. v)


### PR DESCRIPTION
Simple fix: run “tostring” on the version field.

It may be desired to refuse certain types. The motivating case here is
that std.optparse has version set to number 0.
