### PR TITLE
simpler std.string.caps(), uses a frontier pattern

### DIFF
--- a/lib/std/string.lua
+++ b/lib/std/string.lua
@@ -126,9 +126,7 @@ end
 
 
 local function caps(s)
-   return(gsub(s, '(%w)([%w]*)', function(l, ls)
-      return upper(l) .. ls
-   end))
+   return(gsub(s, '%f[%w]%l', string.upper))
 end
 
 


### PR DESCRIPTION
also explicitly matches %l, so string.upper should always run.