### PR TITLE
Update string.lua

### DIFF
--- a/lib/std/string.lua
+++ b/lib/std/string.lua
@@ -133,7 +133,7 @@ end
 
 
 local function escape_shell(s)
-   return(gsub(s, '([ %(%)%\\%[%]\'"])', '\\%1'))
+   return(gsub(s, '([ %(%)%\\%[%]\'"&])', '\\%1'))
 end
 
 


### PR DESCRIPTION
Symbol "&" was missing in replace pattern, it can be interpreted as a command. If the function was meant to correctly escape paths it should be escaped too.